### PR TITLE
Use getYaw() here instead of calculating Yaw

### DIFF
--- a/src/main/java/org/terasology/minimap/rendering/nui/layers/MinimapGrid.java
+++ b/src/main/java/org/terasology/minimap/rendering/nui/layers/MinimapGrid.java
@@ -301,9 +301,8 @@ public class MinimapGrid extends CoreWidget {
         Mesh mesh = Assets.getMesh("engine:UIBillboard").get();
         // The scaling seems to be completely wrong - 0.8f looks ok
         Quat4f q = locationComponent.getWorldRotation();
-        // convert to Euler yaw angle
         // TODO: move into quaternion
-        float rotation = -(float) Math.atan2(2.0 * (q.y * q.w + q.x * q.z), 1.0 - 2.0 * (q.y * q.y - q.z * q.z));
+        float rotation = -1*q.getYaw();
         canvas.drawMesh(mesh, material, screenArea, new Quat4f(0, 0, rotation), new Vector3f(), 0.8f);
     }
 


### PR DESCRIPTION
While working on the Compass module I noticed that the Yaw angle was being calculated here separately instead of using the getYaw() method. 🙂 
To test simply enable the module and see the Minimap working normally.