### PR TITLE
Fix Remove Overlay

### DIFF
--- a/src/main/java/org/terasology/minimap/rendering/nui/layers/MinimapGrid.java
+++ b/src/main/java/org/terasology/minimap/rendering/nui/layers/MinimapGrid.java
@@ -396,7 +396,7 @@ public class MinimapGrid extends CoreWidget {
      * @param overlay the overlay to remove
      */
     public void removeOverlay(MinimapOverlay overlay) {
-        overlays.add(overlay);
+        overlays.remove(overlay);
     }
 
 }


### PR DESCRIPTION
The `removeOverlay` function added an overlay instead of removing it.

**To Test**
 - Call `minimapSystem.removeOverlay()` to remove the specified overlay