### PR TITLE
fix: use correct tile size for minimap grid

### DIFF
--- a/src/main/java/org/terasology/minimap/rendering/nui/layers/MinimapGrid.java
+++ b/src/main/java/org/terasology/minimap/rendering/nui/layers/MinimapGrid.java
@@ -16,6 +16,8 @@ import org.joml.Vector2ic;
 import org.joml.Vector3f;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
+import org.terasology.engine.registry.CoreRegistry;
+import org.terasology.engine.world.block.tiles.WorldAtlas;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.logic.location.LocationComponent;
@@ -94,11 +96,8 @@ public class MinimapGrid extends CoreWidget {
 
                     BlockPart blockPart = BlockPart.TOP;
 
-                    // TODO: security issues
-                    // WorldAtlas worldAtlas = CoreRegistry.get(WorldAtlas.class);
-                    // float tileSize = worldAtlas.getRelativeTileSize();
-
-                    float tileSize = 16f / 256f; // 256f could be replaced by textureAtlas.getWidth();
+                    WorldAtlas worldAtlas = CoreRegistry.get(WorldAtlas.class);
+                    float tileSize = worldAtlas.getRelativeTileSize();
 
                     Vector2fc textureAtlasPos = primaryAppearance.getTextureAtlasPos(blockPart);
 


### PR DESCRIPTION
The tile size of the WorldAtlas varies based on the loaded modules. The minimap has code to query the actual tile size, but it's been commented out ever since it was added 6 years ago, with a comment about security issues which I can't find any more information on. It's using a hardcoded tile size right now, which is causing problems in Metal Renegades. This PR switches to querying the actual tile size; if it does still have security issues, a different solution will probably be required.

![map-old](https://user-images.githubusercontent.com/13039463/126009826-c467a771-c63e-4d31-83fc-cf6fe870f61b.png)
*How the map looks in MR right now - colors are messed up and a grid pattern is visible at all zoom levels except for -8.*

![map-new](https://user-images.githubusercontent.com/13039463/126009827-781000fb-8277-484c-98b1-1f4a69c40e20.png)
*How it looks after this PR, on the same terrain.*